### PR TITLE
Macro substitutions 

### DIFF
--- a/cexp.c
+++ b/cexp.c
@@ -87,6 +87,8 @@
 #include <mdbg.h>
 #endif
 
+#include "utils.h"
+
 /* on RTEMS, this is not always 0, due to strange redirection */
 #define STDIN_FD fileno(stdin)
 
@@ -565,12 +567,14 @@ va_list ap;
 int		argc=0;
 char	*argv[10]; /* limit to 10 arguments */
 char    *p;
+char    *subs = NULL;
 
 	va_start(ap,arg0);
 
 	argv[argc++]="cexp_main";
 	if (arg0) {
-		argv[argc++]=arg0;
+		subs = expand_macro_string_env(arg0);
+		argv[argc++]=subs;
 
 		while ( (p=va_arg(ap,char*)) ) {
 			
@@ -585,7 +589,9 @@ char    *p;
 	}
 
 	va_end(ap);
-	return cexp_main(argc,argv);
+	int r = cexp_main(argc,argv);
+	free(subs);
+	return r;
 }
 
 CexpSigHandlerInstallProc cexpSigHandlerInstaller=0;

--- a/utils.h
+++ b/utils.h
@@ -1,0 +1,110 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description: Misc utility code
+ * ----------------------------------------------------------------------------
+ * This file is part of 'cexp'. It is subject to the license terms in the
+ * LICENSE.txt file found in the top-level directory of this distribution,
+ * and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of 'cexp', including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_MACRO_NAME_LEN 128
+
+/**
+ * Expands a string with macros in it.
+ * Macros must be surrouned by ${}, such as ${PWD} or ${TEST}. Escape
+ * sequences are also supported (i.e. \${PWD} will not be expanded).
+ * Macros in the format $TEST are not recognized or expanded.
+ * \param str Input string
+ * \param resolveMacro Function to return the value of a macro. Returns NULL
+ * if the macro doesn't exist.
+ * \returns heap allocated string containing the transformed input.
+ * The underlying buffer may be larger than the string contained within.
+ */
+static inline char*
+expand_macro_string(const char* str, const char*(*resolveMacro)(const char*))
+{
+  /* result buffer */
+  size_t ml = strlen(str) + 128;
+  char* buf = (char*)malloc(ml);
+  size_t bl = 0;
+  const char* s = NULL;
+
+  for (s = str; *s; ++s) {
+    if (*s == '$' && *(s+1) == '{') {
+      const char* start = s;
+      s+=2; /* skip starting chars */
+
+      /* read macro name */
+      char macroName[MAX_MACRO_NAME_LEN];
+      int n = 0;
+      for (; *s && *s != '}' && n < MAX_MACRO_NAME_LEN-1; ++s)
+        macroName[n++] = *s;
+      macroName[n] = 0;
+
+      /* incomplete macro? or macro too long? */
+      if (!*s || n == MAX_MACRO_NAME_LEN-1) {
+        s = start;
+        goto append_single;
+      }
+
+      const char* e = resolveMacro(macroName);
+      if (!e)
+        e = "";
+
+      /* resize if required */
+      const size_t macLen = strlen(e);
+      if (bl + macLen + 1 >= ml) {
+        ml = bl + macLen + 128;
+        buf = (char*)realloc(buf, ml);
+      }
+
+      /* append the macro value */
+      for (; *e; ++e)
+        buf[bl++] = *e;
+      continue;
+    }
+    else if (*s == '\\' && *(s+1) == '$')
+      /* escaped macro name ${} */
+      s++;
+
+append_single:
+    if (bl >= (ml-1)) {
+      ml += 128;
+      buf = (char*)realloc(buf, ml);
+    }
+    buf[bl++] = *s; /* simply append */
+  }
+
+  buf[bl] = 0;
+
+  return buf;
+}
+
+static inline const char*
+strtools__getenv(const char* n)
+{
+  return getenv(n);
+}
+
+/**
+ * Expand macro string using the environment.
+ * @see expand_macro_string
+ */
+static inline char*
+expand_macro_string_env(const char* str)
+{
+  return expand_macro_string(str, strtools__getenv);
+}


### PR DESCRIPTION
Allows cexpsh to be called like:
```
cexpsh("${EPICS_IOCS}/common/st.cmd.rtems")
```
without needing to use separate functions and heap allocated buffers in cexpsh.